### PR TITLE
http api /scorex/status fix

### DIFF
--- a/src/main/scala/scorex/lagonaki/api/http/ScorexApiRoute.scala
+++ b/src/main/scala/scorex/lagonaki/api/http/ScorexApiRoute.scala
@@ -58,8 +58,8 @@ case class ScorexApiRoute(override val application: Application)(implicit val co
 
       Future.sequence(Seq(bgf, hsf)).map { case statusesSeq =>
         Json.obj(
-          "block generator status" -> statusesSeq.head,
-          "history synchronization status" -> statusesSeq.tail.head
+          "block_generator_status" -> statusesSeq.head,
+          "history_synchronization_status" -> statusesSeq.tail.head
         ).toString()
       }
     }

--- a/src/test/scala/scorex/lagonaki/TestingCommons.scala
+++ b/src/test/scala/scorex/lagonaki/TestingCommons.scala
@@ -32,7 +32,7 @@ object TestingCommons {
         val request = Http(url(peerUrl(a) + "/scorex/status").GET)
         val response = Await.result(request, 10.seconds)
         val json = Json.parse(response.getResponseBody).as[JsObject]
-        assert((json \ "block generator status").asOpt[String].isDefined)
+        assert((json \ "block_generator_status").asOpt[String].isDefined)
       }
     }
     apps

--- a/src/test/scala/scorex/lagonaki/integration/APISpecification.scala
+++ b/src/test/scala/scorex/lagonaki/integration/APISpecification.scala
@@ -18,8 +18,8 @@ class APISpecification extends FunSuite with Matchers with BeforeAndAfterAll wit
 
   test("Scorex API route") {
     val json = getRequest("/scorex/status")
-    (json \ "block generator status").asOpt[String].isDefined shouldBe true
-    (json \ "history synchronization status").asOpt[String].isDefined shouldBe true
+    (json \ "block_generator_status").asOpt[String].isDefined shouldBe true
+    (json \ "history_synchronization_status").asOpt[String].isDefined shouldBe true
     (getRequest("/scorex/version") \ "version").as[String] should (startWith("Scorex") and include("v."))
   }
 


### PR DESCRIPTION
For JavaScript clients It's much better don't use spaces in json response members. 