### PR TITLE
Some cleanup and small improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++=
   Dependencies.db ++
     Dependencies.http ++
     Dependencies.akka ++
-    Dependencies.serizalization ++
+    Dependencies.serialization ++
     Dependencies.testKit ++
     Dependencies.logging
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     "net.databinder.dispatch" %% "dispatch-core" % "+" % "test"
   )
 
-  lazy val serizalization = Seq(
+  lazy val serialization = Seq(
     "com.google.guava" % "guava" % "18.+",
     "com.typesafe.play" %% "play-json" % "2.4.+"
   )

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,98 +1,105 @@
 <scalastyle>
- <name>Scalastyle standard configuration</name>
- <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxLineLength"><![CDATA[160]]></parameter>
-   <parameter name="tabSize"><![CDATA[4]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
-  <parameters>
-   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
-  <parameters>
-   <parameter name="maxParameters"><![CDATA[8]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
-  <parameters>
-   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[println]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
-  <parameters>
-   <parameter name="maxTypes"><![CDATA[30]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
-  <parameters>
-   <parameter name="maximum"><![CDATA[10]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="false">
-  <parameters>
-   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
-   <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxLength"><![CDATA[50]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
-  <parameters>
-   <parameter name="maxMethods"><![CDATA[30]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+    <name>Scalastyle standard configuration</name>
+    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+            <parameter name="tabSize"><![CDATA[4]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="maxParameters"><![CDATA[8]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker"
+           enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker"
+           enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[println]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+        <parameters>
+            <parameter name="maxTypes"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+        <parameters>
+            <parameter name="maximum"><![CDATA[10]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="false">
+        <parameters>
+            <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+            <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLength"><![CDATA[50]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+        <parameters>
+            <parameter name="maxMethods"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.scalariform.TodoCommentChecker" enabled="true">
+        <parameters>
+            <parameter name="words">TODO|FIXME|todo|fixme|bug|BUG</parameter>
+        </parameters>
+    </check>
 </scalastyle>

--- a/scorex-basics/build.sbt
+++ b/scorex-basics/build.sbt
@@ -3,7 +3,7 @@ name := "scorex-basics"
 resolvers += "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
 
 libraryDependencies ++=
-    Dependencies.serizalization ++
+    Dependencies.serialization ++
     Dependencies.akka ++
     Dependencies.p2p ++
     Dependencies.db ++

--- a/scorex-basics/src/test/scala/scorex/network/HandshakeSpecification.scala
+++ b/scorex-basics/src/test/scala/scorex/network/HandshakeSpecification.scala
@@ -31,7 +31,7 @@ with Matchers {
     port <- Gen.choose(0, MaxPort)
   } yield new InetSocketAddress(InetAddress.getByName(s"$ip1.$ip2.$ip3.$ip4"), port)
 
-  val validNumers =
+  val validNumbers =
     for (n <- Gen.choose(Integer.MIN_VALUE + 1, Integer.MAX_VALUE)) yield n
 
   property("handshake should remain the same after serialization/deserialization") {

--- a/scorex-consensus/build.sbt
+++ b/scorex-consensus/build.sbt
@@ -1,3 +1,3 @@
 name := "scorex-consensus"
 
-libraryDependencies ++= Dependencies.testKit ++ Dependencies.serizalization ++ Dependencies.logging
+libraryDependencies ++= Dependencies.testKit ++ Dependencies.serialization ++ Dependencies.logging

--- a/scorex-transaction/build.sbt
+++ b/scorex-transaction/build.sbt
@@ -3,7 +3,7 @@ name := "scorex-transaction"
 libraryDependencies ++=
   Dependencies.testKit ++
   Dependencies.db ++
-  Dependencies.serizalization ++
+  Dependencies.serialization ++
   Dependencies.logging ++
   Seq(
     "com.github.pathikrit" %% "better-files" % "2.13.0"

--- a/scorex-transaction/src/main/scala/scorex/transaction/GenesisTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/GenesisTransaction.scala
@@ -1,5 +1,7 @@
 package scorex.transaction
 
+import java.math.BigInteger
+
 import com.google.common.primitives.{Bytes, Ints, Longs}
 import play.api.libs.json.{JsObject, Json}
 import scorex.account.Account
@@ -69,10 +71,10 @@ object GenesisTransaction {
   private val RECIPIENT_LENGTH = Account.AddressLength
   private val BASE_LENGTH = TimestampLength + RECIPIENT_LENGTH + AmountLength
 
-  def generateSignature(recipient: Account, amount: BigDecimal, timestamp: Long): Array[Byte] = {
+  def generateSignature(recipient: Account, amount: Long, timestamp: Long): Array[Byte] = {
     val typeBytes = Bytes.ensureCapacity(Ints.toByteArray(TransactionType.GenesisTransaction.id), TypeLength, 0)
     val timestampBytes = Bytes.ensureCapacity(Longs.toByteArray(timestamp), TimestampLength, 0)
-    val amountBytes = amount.bigDecimal.unscaledValue().toByteArray
+    val amountBytes = BigInteger.valueOf(amount).toByteArray
     val amountFill = new Array[Byte](AmountLength - amountBytes.length)
 
     val data = Bytes.concat(typeBytes, timestampBytes,
@@ -82,7 +84,7 @@ object GenesisTransaction {
     Bytes.concat(h, h)
   }
 
-  private[transaction] def parse(data: Array[Byte]): LagonakiTransaction = {
+  private[transaction] def parseTransactionData(data: Array[Byte]): LagonakiTransaction = {
     require(data.length >= BASE_LENGTH, "Data does not match base length")
 
     var position = 0

--- a/scorex-transaction/src/main/scala/scorex/transaction/LagonakiTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/LagonakiTransaction.scala
@@ -89,10 +89,10 @@ object LagonakiTransaction {
   def parse(data: Array[Byte]): Try[LagonakiTransaction] = Try {
     data.head match {
       case txType: Byte if txType == TransactionType.GenesisTransaction.id =>
-        GenesisTransaction.parse(data.tail)
+        GenesisTransaction.parseTransactionData(data.tail)
 
       case txType: Byte if txType == TransactionType.PaymentTransaction.id =>
-        PaymentTransaction.parse(data.tail)
+        PaymentTransaction.parseTransactionData(data.tail)
 
       case txType => throw new Exception(s"Invalid transaction type: $txType")
     }

--- a/scorex-transaction/src/main/scala/scorex/transaction/PaymentTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/PaymentTransaction.scala
@@ -89,7 +89,7 @@ object PaymentTransaction {
     PaymentTransaction(sender, recipient, amount, fee, timestamp, sig)
   }
 
-  private[transaction] def parse(data: Array[Byte]) = {
+  private[transaction] def parseTransactionData(data: Array[Byte]) = {
     require(data.length >= BaseLength, "Data does not match base length")
 
     var position = 0

--- a/scorex-transaction/src/test/scala/scorex/transaction/GenesisTransactionTests.scala
+++ b/scorex-transaction/src/test/scala/scorex/transaction/GenesisTransactionTests.scala
@@ -1,0 +1,52 @@
+package scorex.transaction
+
+import org.joda.time.DateTime
+import org.scalatest._
+import scorex.account.Account
+
+class GenesisTransactionTests extends FlatSpec with Matchers {
+
+  val defaultRecipient = new Account("jACSbUoHi4eWgNu6vzAnEx583NwmUAVfS");
+
+  "GenesisTransaction Signature" should "be the same" in {
+    val balance = 457L
+    val timestamp = 2398762345L
+    val signature = GenesisTransaction.generateSignature(defaultRecipient, balance, timestamp)
+
+    val expected = "1E90EE1ECD68C137009F64F546198E6871D199E3D97AD48A35D3B264B089BD761E90EE1ECD68C137009F64F546198E6871D199E3D97AD48A35D3B264B089BD76"
+    val actual = Hex.valueOf(signature)
+
+    assert(actual == expected)
+  }
+
+  "GenesisTransaction parse from Bytes" should "work fine" in {
+    val serialized = "0100000001121AF37E01CE7293C877DC3FC457A634CE87FC0A9306B77D0108FD3A3D00000022E43063A2"
+
+    val bytes = Hex.fromString(serialized)
+
+    val actualTransaction = GenesisTransaction.parseTransactionData(bytes.tail)
+
+    val balance = 149857264546L
+    val timestamp = 4598723454L
+    val expectedTransaction = new GenesisTransaction(defaultRecipient, balance, timestamp)
+
+    actualTransaction should equal(expectedTransaction)
+  }
+
+  "GenesisTransaction" should "serialize/deserialize" in {
+    val source = new GenesisTransaction(defaultRecipient, 3459L, 123456L)
+
+    val bytes = source.bytes
+
+    val dest = GenesisTransaction.parseTransactionData(bytes.tail)
+
+    source should equal (dest)
+  }
+
+  object Hex {
+    def valueOf(buf: Array[Byte]): String = buf.map("%02X" format _).mkString
+
+    def fromString(str: String): Array[Byte] = str.sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)
+  }
+
+}

--- a/scorex-transaction/src/test/scala/scorex/transaction/TransactionTestSuite.scala
+++ b/scorex-transaction/src/test/scala/scorex/transaction/TransactionTestSuite.scala
@@ -5,5 +5,6 @@ import org.scalatest.Suites
 class TransactionTestSuite extends Suites(
   new TransactionSpecification,
   new StoredStateUnitTests,
-  new RowSpecification
+  new RowSpecification,
+  new GenesisTransactionTests
 )


### PR DESCRIPTION
BigDecima type usage was removed from GenesisTransaction.generateSignature method.
Method parse was renamed in GenesisTransaction and PaymentTransaction into parseTransactionData.
Few typos were corrected.
Added a TODO comments check to scalastyle.